### PR TITLE
Track fetch output so scheduled runs persist data

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: github.ref_name == github.event.repository.default_branch && steps.check_changes.outputs.has_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -53,7 +53,7 @@ jobs:
           git push
 
       - name: Create issue on failure
-        if: failure()
+        if: github.ref_name == github.event.repository.default_branch && failure()
         uses: actions/github-script@v7
         with:
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ CLAUDE.md
 # Downloaded data (keep directory)
 downloaded/*
 !downloaded/.gitkeep
-
-# Processed data (keep directory)
-processed/*
-!processed/.gitkeep


### PR DESCRIPTION
Scheduled fetch downloaded this source every day and discarded the result, because `.gitignore` excluded `processed/`. New entries never reached the repository. Dropped the ignore rule so fetch output is tracked and each run persists what it downloaded.

The commit and issue-filing steps in `fetch.yml` now run only on the default branch, matching the guard data-nz and five sibling repos already carry. Without it those steps fire inside pull requests, where the checkout is a detached merge commit with nowhere to push, and every run opens a spurious failure issue.
